### PR TITLE
#11 Add aad-pod-id-rbac support

### DIFF
--- a/generators/azure-aks/choices/features.json
+++ b/generators/azure-aks/choices/features.json
@@ -12,6 +12,10 @@
         "value": "rbac"
     },
     {
+        "name": "Azure Active Directory Pod Id (aad-pod-id)",
+        "value": "aad-pod-id"
+    },    
+    {
         "name": "Cert-manager",
         "value": "cert-manager"
     },

--- a/generators/azure-aks/templates/aad-pod-id/aad-pod-id-rbac.tf
+++ b/generators/azure-aks/templates/aad-pod-id/aad-pod-id-rbac.tf
@@ -1,0 +1,4 @@
+module "aad-pod-identity-rbac" {
+  source  = "cloudcommons/aad-pod-identity-rbac/kubernetes"
+  version = "0.1.0"
+}

--- a/generators/azure-aks/templates/aad-pod-id/aad-pod-id.tf
+++ b/generators/azure-aks/templates/aad-pod-id/aad-pod-id.tf
@@ -1,0 +1,4 @@
+module "aad-pod-identity" {
+  source  = "cloudcommons/aad-pod-identity/kubernetes"
+  version = "0.1.0"
+}

--- a/generators/azure-aks/writer.js
+++ b/generators/azure-aks/writer.js
@@ -11,6 +11,7 @@ module.exports = function (terraform, fsTools, answers, options) {
         acrEnabled: answers.features.includes("acr"),
         rbacEnabled: answers.features.includes("rbac"),
         autoScalingEnabled: answers.features.includes("auto-scaler"),
+        aadPodId: answers.features.includes("aad-pod-id"),
         minNodeCount: this.autoScalingEnabled === true ? answers.minNodeCount : 0,
         maxNodeCount: this.autoScalingEnabled === true ? answers.maxNodeCount : 0,
         resourceGroupReference: terraform.resolveDependency(answers.resourceGroup, `${answers.resourceGroup}.name`, "var.AKS_RESOURCE_GROUP_NAME"),
@@ -28,6 +29,7 @@ module.exports = function (terraform, fsTools, answers, options) {
         fsTools.copyTo(`cert-manager/${answers.certManagerVersion}/jetstack-helm-repo.tf`, "cert-manager-jetstack-helm-repo.tf", answers);
         fsTools.copyTo(`cert-manager/${answers.certManagerVersion}/cert-manager.tf`, "cert-manager.tf", answers);
     }
+
     if (answers.features.includes("atarraya")) {
         fsTools.copyTo("atarraya/atarraya.tf", "atarraya.tf", answers);
     }
@@ -42,5 +44,16 @@ module.exports = function (terraform, fsTools, answers, options) {
         fsTools.copyTo("helm/v2/service-account.tf", "tiller-service-account.tf");
         var helmPrivder = require('./templates/helm/v2/providers.js');
         helmPrivder.copy(terraform, answers);
+    }
+
+    if (answers.aadPodId) {
+        if (answers.rbacEnabled) {
+            fsTools.copyTo("aad-pod-id/aad-pod-id-rbac.tf", "aad-pod-id-rbac.tf", answers);
+        }
+        else {
+            console.log("aad-pod-id not support without RBAC yet");
+            // TODO This module is not published yet
+            //fsTools.copyTo("aad-pod-id/aad-pod-id.tf", "aad-pod-id.tf", answers);
+        }
     }
 }

--- a/test/azure-aks.js
+++ b/test/azure-aks.js
@@ -32,6 +32,7 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.file('variables.tf.json');
                 assert.file('providers.tf.json');
                 assert.file('output.tf.json');
+                assert.noFile('aad-pod-id-rbac.tf');
             });
 
             it('Defines terraform variables', () => {
@@ -122,6 +123,7 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.file('variables.tf.json');
                 assert.file('providers.tf.json');
                 assert.file('output.tf.json');
+                assert.noFile('aad-pod-id-rbac.tf');
             });
 
             it('Defines terraform variables', () => {
@@ -201,6 +203,7 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.file('variables.tf.json');
                 assert.file('providers.tf.json');
                 assert.file('output.tf.json');
+                assert.noFile('aad-pod-id-rbac.tf');
             });
 
             it('Defines terraform variables', () => {
@@ -258,6 +261,93 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.fileContent('providers.tf.json', '"version": "~> 1.0.0"');
             });
         });        
+
+        describe('Creates an Azure Kubernetes Service with RBAC and AzureAD Pod Identity', () => {
+            var prompts = {
+                name: 'cloudcommons',
+                resourceGroup: 'azurerm_resource_group.workspace',
+                location: 'westeurope',
+                kubernetesVersion: '1.15.7',
+                vmsize: 'Standard_DS3_v2',
+                vms: 3,
+                adminUser: 'cloudcommons-admin',
+                sshKey: 'sskKey',
+                clientId: 'cliendId',
+                clientSecret: 'clientSecret',
+                features: ["network-plugin", "network-policy", "rbac", "aad-pod-id"]
+            };
+
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../generators/azure-aks'))
+                    .withPrompts(prompts)
+                    .once('end', done);
+            });
+
+            it('Generates AKS files', () => {
+                assert.file('aks.tf');
+                assert.file('terraform.tfvars.json');
+                assert.file('variables.tf.json');
+                assert.file('providers.tf.json');
+                assert.file('output.tf.json');
+                assert.file('aad-pod-id-rbac.tf');
+            });
+
+            it('Defines terraform variables', () => {
+                assert.fileContent('variables.tf.json', '"CREATOR":');
+                assert.fileContent('variables.tf.json', '"LOCATION":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_CLUSTER_NAME":');
+                assert.fileContent('variables.tf.json', '"ADMIN_USER":');
+                assert.fileContent('variables.tf.json', '"SSH_KEY":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_VERSION":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_AGENT_COUNT":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_VM_SIZE":');
+                assert.fileContent('variables.tf.json', '"OS_DISK_SIZE_GB":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_CLIENT_ID":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_CLIENT_SECRET":');
+                assert.fileContent('variables.tf.json', '"RBAC_ENABLED":');
+                assert.noFileContent('variables.tf.json', '"AKS_RESOURCE_GROUP_NAME":');
+            });
+
+            it('Disables auto-scaler', () => {
+                assert.fileContent('variables.tf.json', '"AUTO_SCALING_ENABLED":');
+                assert.fileContent('variables.tf.json', `"default": false`);
+                assert.fileContent('variables.tf.json', '"AUTO_SCALING_MIN_COUNT":');
+                assert.fileContent('variables.tf.json', `"default": 0`);
+                assert.fileContent('variables.tf.json', '"AUTO_SCALING_MAX_COUNT":');
+                assert.fileContent('variables.tf.json', `"default": 0`);
+            });
+
+            it('Includes AKS in the variables', () => {
+                assert.fileContent('terraform.tfvars.json', `"CREATOR": "cloudcommons"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_CLUSTER_NAME": "${prompts.name}"`);
+                assert.fileContent('terraform.tfvars.json', `"LOCATION": "${prompts.location}"`);
+                assert.fileContent('terraform.tfvars.json', `"ADMIN_USER": "${prompts.adminUser}"`);
+                assert.fileContent('terraform.tfvars.json', `"SSH_KEY": "${prompts.sshKey}"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_VERSION": "${prompts.kubernetesVersion}"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_AGENT_COUNT": ${prompts.vms}`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_VM_SIZE": "${prompts.vmsize}"`);
+                assert.fileContent('terraform.tfvars.json', `"OS_DISK_SIZE_GB": 60`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_CLIENT_ID": "${prompts.clientId}"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_CLIENT_SECRET": "${prompts.clientSecret}"`);
+                assert.fileContent('terraform.tfvars.json', `"RBAC_ENABLED": true`);
+                assert.noFileContent('terraform.tfvars.json', '"AKS_RESOURCE_GROUP_NAME":');
+            });
+
+            it('Creates the right output values', () => {
+                var key = `module.${prompts.name}-kubernetes`;
+                assert.fileContent('output.tf.json', '"AKS_KUBE_CONFIG":');
+                assert.fileContent('output.tf.json', `${key}.kube_config_raw`);
+                assert.fileContent('output.tf.json', '"AKS_KUBE_CONFIG_RAW":');
+            });
+
+            it('Adds azurerm provider', () => {
+                assert.fileContent('providers.tf.json', '"provider":');
+                assert.fileContent('providers.tf.json', '"azurerm":');
+                assert.fileContent('providers.tf.json', '"helm":');
+                assert.fileContent('providers.tf.json', '"version": "~> 1.0.0"');
+            });
+        });        
     });
     describe('Using existing resource group', () => {
         describe('Creates an Azure Kubernetes Server with Helm 3', () => {
@@ -288,6 +378,7 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.file('variables.tf.json');
                 assert.file('providers.tf.json');
                 assert.file('output.tf.json');
+                assert.noFile('aad-pod-id-rbac.tf');
             });
 
             it('Defines terraform variables', () => {
@@ -370,6 +461,7 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.file('variables.tf.json');
                 assert.file('providers.tf.json');
                 assert.file('output.tf.json');
+                assert.noFile('aad-pod-id-rbac.tf');
             });
 
             it('Defines terraform variables', () => {
@@ -450,6 +542,7 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.file('variables.tf.json');
                 assert.file('providers.tf.json');
                 assert.file('output.tf.json');
+                assert.noFile('aad-pod-id-rbac.tf');
             });
 
             it('Defines terraform variables', () => {
@@ -506,6 +599,86 @@ describe("cloudcommons/cli:azure-aks", function () {
                 assert.fileContent('providers.tf.json', '"helm":');
                 assert.fileContent('providers.tf.json', '"version": "~> 1.0.0"');
             });
-        });      
+        });  
+        
+
+        describe('Creates an Azure Kubernetes Service with RBAC and AzureAD Pod Identity', () => {
+            var prompts = {
+                name: 'cloudcommons',
+                resourceGroup: 'workspace',
+                location: 'westeurope',
+                kubernetesVersion: '1.15.7',
+                vmsize: 'Standard_DS3_v2',
+                vms: 3,
+                adminUser: 'cloudcommons-admin',
+                sshKey: 'sskKey',
+                clientId: 'cliendId',
+                clientSecret: 'clientSecret',
+                features: ["network-plugin", "network-policy", "rbac", "aad-pod-id"]
+            };
+
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../generators/azure-aks'))
+                    .withPrompts(prompts)
+                    .once('end', done);
+            });
+
+            it('Generates AKS files', () => {
+                assert.file('aks.tf');
+                assert.file('terraform.tfvars.json');
+                assert.file('variables.tf.json');
+                assert.file('providers.tf.json');
+                assert.file('output.tf.json');
+                assert.file('aad-pod-id-rbac.tf');
+            });
+
+            it('Defines terraform variables', () => {
+                assert.fileContent('variables.tf.json', '"CREATOR":');
+                assert.fileContent('variables.tf.json', '"LOCATION":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_CLUSTER_NAME":');
+                assert.fileContent('variables.tf.json', '"ADMIN_USER":');
+                assert.fileContent('variables.tf.json', '"SSH_KEY":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_VERSION":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_AGENT_COUNT":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_VM_SIZE":');
+                assert.fileContent('variables.tf.json', '"OS_DISK_SIZE_GB":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_CLIENT_ID":');
+                assert.fileContent('variables.tf.json', '"KUBERNETES_CLIENT_SECRET":');
+                assert.fileContent('variables.tf.json', '"RBAC_ENABLED":');
+                assert.fileContent('variables.tf.json', '"AKS_RESOURCE_GROUP_NAME":');
+            });
+
+            it('Includes AKS in the variables', () => {
+                assert.fileContent('terraform.tfvars.json', `"CREATOR": "cloudcommons"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_CLUSTER_NAME": "${prompts.name}"`);
+                assert.fileContent('terraform.tfvars.json', `"LOCATION": "${prompts.location}"`);
+                assert.fileContent('terraform.tfvars.json', `"ADMIN_USER": "${prompts.adminUser}"`);
+                assert.fileContent('terraform.tfvars.json', `"SSH_KEY": "${prompts.sshKey}"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_VERSION": "${prompts.kubernetesVersion}"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_AGENT_COUNT": ${prompts.vms}`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_VM_SIZE": "${prompts.vmsize}"`);
+                assert.fileContent('terraform.tfvars.json', `"OS_DISK_SIZE_GB": 60`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_CLIENT_ID": "${prompts.clientId}"`);
+                assert.fileContent('terraform.tfvars.json', `"KUBERNETES_CLIENT_SECRET": "${prompts.clientSecret}"`);
+                assert.fileContent('terraform.tfvars.json', `"RBAC_ENABLED": true`);
+                assert.fileContent('terraform.tfvars.json', `"AKS_RESOURCE_GROUP_NAME": "${prompts.resourceGroup}"`);
+            });
+
+            it('Creates the right output values', () => {
+                var key = `module.${prompts.name}-kubernetes`;
+                assert.fileContent('output.tf.json', '"AKS_KUBE_CONFIG":');
+                assert.fileContent('output.tf.json', `${key}.kube_config_raw`);
+                assert.fileContent('output.tf.json', '"AKS_KUBE_CONFIG_RAW":');
+                assert.fileContent('output.tf.json', `${key}.kube_config_raw`);
+            });
+
+            it('Adds azurerm provider', () => {
+                assert.fileContent('providers.tf.json', '"provider":');
+                assert.fileContent('providers.tf.json', '"azurerm":');
+                assert.fileContent('providers.tf.json', '"helm":');
+                assert.fileContent('providers.tf.json', '"version": "~> 1.0.0"');
+            });
+        });        
     });
 });


### PR DESCRIPTION
Adds aad-pod-id-rbac support

Support to aad-pod-id (without RBAC) is yet to come.