### PR TITLE
CloudCommons Kubernetes Application version bump

### DIFF
--- a/generators/azure-aks-app/templates/app.tf
+++ b/generators/azure-aks-app/templates/app.tf
@@ -8,7 +8,7 @@ locals {
 
 module "<%= name %>" {
   source                          = "cloudcommons/application/kubernetes"
-  version                         = "0.1.9"
+  version                         = "0.1.10"
   APP_NAME                        = var.APP
   UID                             = local.uid
   ENVIRONMENT                     = var.ENVIRONMENT


### PR DESCRIPTION
This PR bumps our CloudCommons Kubernetes Application version to [0.1.10](https://registry.terraform.io/modules/cloudcommons/application/kubernetes/0.1.10)